### PR TITLE
Add config and use group-id-suffix

### DIFF
--- a/src/main/java/no/fintlabs/config/KafkaConfig.java
+++ b/src/main/java/no/fintlabs/config/KafkaConfig.java
@@ -1,9 +1,25 @@
 package no.fintlabs.config;
 
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 
+@Slf4j
 @Configuration
 public class KafkaConfig {
 
+    public static final int SUFFIX_LENGTH = 8;
+    private String groupIdSuffix;
 
+    public KafkaConfig(Environment environment) {
+        groupIdSuffix = RandomStringUtils.random(SUFFIX_LENGTH, true, true).toLowerCase();
+
+        String groupId = environment.getProperty("spring.kafka.consumer.group-id");
+        log.info(String.format("Group-id: %s-%s", groupId, groupIdSuffix));
+    }
+
+    public String getGroupIdSuffix() {
+        return groupIdSuffix;
+    }
 }

--- a/src/main/java/no/fintlabs/event/request/RequestEventTopicListener.java
+++ b/src/main/java/no/fintlabs/event/request/RequestEventTopicListener.java
@@ -2,6 +2,7 @@ package no.fintlabs.event.request;
 
 import lombok.extern.slf4j.Slf4j;
 import no.fintlabs.adapter.models.RequestFintEvent;
+import no.fintlabs.config.KafkaConfig;
 import no.fintlabs.kafka.common.topic.pattern.FormattedTopicComponentPattern;
 import no.fintlabs.kafka.common.topic.pattern.ValidatedTopicComponentPattern;
 import no.fintlabs.kafka.event.EventConsumerConfiguration;
@@ -20,9 +21,12 @@ public class RequestEventTopicListener {
 
     private final RequestEventService requestEventService;
 
-    public RequestEventTopicListener(EventConsumerFactoryService eventConsumerFactoryService, RequestEventService requestEventService) {
+    private final KafkaConfig kafkaConfig;
+
+    public RequestEventTopicListener(EventConsumerFactoryService eventConsumerFactoryService, RequestEventService requestEventService, KafkaConfig kafkaConfig) {
         this.eventConsumerFactoryService = eventConsumerFactoryService;
         this.requestEventService = requestEventService;
+        this.kafkaConfig = kafkaConfig;
     }
 
     @PostConstruct
@@ -42,6 +46,7 @@ public class RequestEventTopicListener {
                 EventConsumerConfiguration
                         .builder()
                         .seekingOffsetResetOnAssignment(true)
+                        .groupIdSuffix(kafkaConfig.getGroupIdSuffix())
                         .build()
         ).createContainer(eventTopicNameParameters);
     }

--- a/src/main/java/no/fintlabs/event/response/ResponseEventTopicListener.java
+++ b/src/main/java/no/fintlabs/event/response/ResponseEventTopicListener.java
@@ -2,6 +2,7 @@ package no.fintlabs.event.response;
 
 import lombok.extern.slf4j.Slf4j;
 import no.fintlabs.adapter.models.ResponseFintEvent;
+import no.fintlabs.config.KafkaConfig;
 import no.fintlabs.event.request.RequestEventService;
 import no.fintlabs.kafka.common.topic.pattern.FormattedTopicComponentPattern;
 import no.fintlabs.kafka.common.topic.pattern.ValidatedTopicComponentPattern;
@@ -20,9 +21,12 @@ public class ResponseEventTopicListener {
 
     private final RequestEventService requestEventService;
 
-    public ResponseEventTopicListener(EventConsumerFactoryService eventConsumerFactoryService, RequestEventService requestEventService) {
+    private final KafkaConfig kafkaConfig;
+
+    public ResponseEventTopicListener(EventConsumerFactoryService eventConsumerFactoryService, RequestEventService requestEventService, KafkaConfig kafkaConfig) {
         this.eventConsumerFactoryService = eventConsumerFactoryService;
         this.requestEventService = requestEventService;
+        this.kafkaConfig = kafkaConfig;
     }
 
     @PostConstruct
@@ -42,6 +46,7 @@ public class ResponseEventTopicListener {
                 EventConsumerConfiguration
                         .builder()
                         .seekingOffsetResetOnAssignment(true)
+                        .groupIdSuffix(kafkaConfig.getGroupIdSuffix())
                         .build()
         ).createContainer(eventTopicNameParameters);
     }


### PR DESCRIPTION
For å støtte horisontal skalering lage det en groupId suffix som settes på kafka consumerene. Dette gjør at alle eventer treffer alle providerene, og det er ønskelig. 