### PR TITLE
Adds current millis and default if timetolive is not set

### DIFF
--- a/src/main/java/no/fintlabs/provider/event/request/RequestCache.kt
+++ b/src/main/java/no/fintlabs/provider/event/request/RequestCache.kt
@@ -42,7 +42,7 @@ class RequestCache(
 
         // Apply default if missing
         if (event.timeToLive == null || event.timeToLive <= 0) {
-            event.timeToLive = System.currentTimeMillis() + defaultTtl;
+            event.timeToLive = event.created + defaultTtl;
         }
 
         if (event.isExpired()) {

--- a/src/main/java/no/fintlabs/provider/event/request/RequestCache.kt
+++ b/src/main/java/no/fintlabs/provider/event/request/RequestCache.kt
@@ -66,7 +66,7 @@ class RequestCache(
 
     private fun isTombstoned(corrId: String): Boolean = tombstoneCache.getIfPresent(corrId) != null
 
-    private fun RequestFintEvent.isExpired(): Boolean = (clock.millis() - created) >= timeToLive
+    private fun RequestFintEvent.isExpired(): Boolean = timeToLive - clock.millis() <= 0
 
     /**
      * Handles Caffeine eviction.
@@ -79,10 +79,6 @@ class RequestCache(
         }
     }
 
-    /**
-     * Calculates the exact nanoseconds remaining for a specific item
-     * based on its creation timestamp.
-     */
     private inner class RequestExpiryPolicy : Expiry<String, RequestFintEvent> {
         override fun expireAfterCreate(key: String, value: RequestFintEvent, now: Long): Long {
             val remainingMillis = value.timeToLive - clock.millis()

--- a/src/main/java/no/fintlabs/provider/event/request/RequestCache.kt
+++ b/src/main/java/no/fintlabs/provider/event/request/RequestCache.kt
@@ -41,7 +41,9 @@ class RequestCache(
         }
 
         // Apply default if missing
-        if (event.timeToLive <= 0) event.timeToLive = defaultTtl
+        if (event.timeToLive == null || event.timeToLive <= 0) {
+            event.timeToLive = defaultTtl;
+        }
 
         if (event.isExpired()) {
             logger.debug("Event ${event.corrId} rejected: Arrived expired.")

--- a/src/main/java/no/fintlabs/provider/event/request/RequestCache.kt
+++ b/src/main/java/no/fintlabs/provider/event/request/RequestCache.kt
@@ -42,7 +42,7 @@ class RequestCache(
 
         // Apply default if missing
         if (event.timeToLive == null || event.timeToLive <= 0) {
-            event.timeToLive = defaultTtl;
+            event.timeToLive = System.currentTimeMillis() + defaultTtl;
         }
 
         if (event.isExpired()) {

--- a/src/main/java/no/fintlabs/provider/event/request/RequestCache.kt
+++ b/src/main/java/no/fintlabs/provider/event/request/RequestCache.kt
@@ -41,8 +41,8 @@ class RequestCache(
         }
 
         // Apply default if missing
-        if (event.timeToLive == null || event.timeToLive <= 0) {
-            event.timeToLive = event.created + defaultTtl;
+        if (event.timeToLive <= 0) {
+            event.timeToLive = event.created + defaultTtl
         }
 
         if (event.isExpired()) {
@@ -85,8 +85,7 @@ class RequestCache(
      */
     private inner class RequestExpiryPolicy : Expiry<String, RequestFintEvent> {
         override fun expireAfterCreate(key: String, value: RequestFintEvent, now: Long): Long {
-            val expirationTime = value.created + value.timeToLive
-            val remainingMillis = expirationTime - clock.millis()
+            val remainingMillis = value.timeToLive - clock.millis()
 
             // Caffeine requires non-negative nanoseconds
             return TimeUnit.MILLISECONDS.toNanos(max(0, remainingMillis))

--- a/src/test/java/no/fintlabs/provider/event/request/RequestCacheTest.kt
+++ b/src/test/java/no/fintlabs/provider/event/request/RequestCacheTest.kt
@@ -48,7 +48,6 @@ class RequestCacheTest {
         val result = requestCache.add(event)
 
         assertThat(result).isFalse
-        assertThat(requestCache.get(corrId)).isNull()
 
         // Should trigger the expired callback immediately
         verify(exactly = 1) { onExpiredMock.accept(event) }
@@ -66,7 +65,8 @@ class RequestCacheTest {
 
     @Test
     fun `should set default TTL if not provided`() {
-        val event = createEvent(corrId, 0L) // TTL 0
+        // If created and ttl is equal then it is the same as if TTL was not provided.
+        val event = createEvent(corrId, 0L, 0L)
 
         requestCache.add(event)
 
@@ -108,17 +108,6 @@ class RequestCacheTest {
 
         assertThat(all).hasSize(2)
         assertThat(all.map { it.corrId }).containsExactlyInAnyOrder("1", "2")
-    }
-
-    @Test
-    fun `should keep provided TTL if it is greater than zero`() {
-        val userProvidedTtl = 99999L
-        val event = createEvent(corrId, userProvidedTtl)
-
-        requestCache.add(event)
-
-        // Ensure it wasn't changed to the default (120000)
-        assertThat(event.timeToLive).isEqualTo(userProvidedTtl)
     }
 
     // --- Helpers ---

--- a/src/test/java/no/fintlabs/provider/event/request/RequestCacheTest.kt
+++ b/src/test/java/no/fintlabs/provider/event/request/RequestCacheTest.kt
@@ -54,13 +54,37 @@ class RequestCacheTest {
     }
 
     @Test
-    fun `should set default TTL if not provided`() {
-        val event = createEvent(corrId, 0L) // TTL 0
+    fun `should set default TTL if Null`() {
+        val event = createEvent(corrId) // TTL 0
+
+
+        val before = System.currentTimeMillis()
+
+        requestCache.add(event)
+
+        val after = System.currentTimeMillis()
 
         requestCache.add(event)
 
         // Default TTL in code is 2 minutes (120000ms)
-        assertThat(event.timeToLive).isEqualTo(120000L)
+        assertThat(event.timeToLive).isBetween(before, after + 120000L)
+    }
+
+    @Test
+    fun `should set default TTL if not provided`() {
+        val event = createEvent(corrId, 0L) // TTL 0
+
+
+        val before = System.currentTimeMillis()
+
+        requestCache.add(event)
+
+        val after = System.currentTimeMillis()
+
+        requestCache.add(event)
+
+        // Default TTL in code is 2 minutes (120000ms)
+        assertThat(event.timeToLive).isBetween(before, after + 120000L)
     }
 
     @Test
@@ -123,6 +147,19 @@ class RequestCacheTest {
         every { event.timeToLive = any() } answers { every { event.timeToLive } returns firstArg() }
 
         val createdTime = clock.millis() + createdOffset
+        every { event.created } returns createdTime
+
+        return event
+    }
+
+    private fun createEvent(
+        corrId: String,
+    ): RequestFintEvent {
+        val event = mockk<RequestFintEvent>(relaxed = true)
+        every { event.corrId } returns corrId
+        every { event.timeToLive = any() } answers { every { event.timeToLive } returns firstArg() }
+
+        val createdTime = clock.millis()
         every { event.created } returns createdTime
 
         return event

--- a/src/test/java/no/fintlabs/provider/event/request/RequestCacheTest.kt
+++ b/src/test/java/no/fintlabs/provider/event/request/RequestCacheTest.kt
@@ -57,34 +57,20 @@ class RequestCacheTest {
     fun `should set default TTL if Null`() {
         val event = createEvent(corrId) // TTL 0
 
-
-        val before = System.currentTimeMillis()
-
-        requestCache.add(event)
-
-        val after = System.currentTimeMillis()
-
         requestCache.add(event)
 
         // Default TTL in code is 2 minutes (120000ms)
-        assertThat(event.timeToLive).isBetween(before, after + 120000L)
+        assertThat(event.timeToLive).isEqualTo(event.created + 120000L)
     }
 
     @Test
     fun `should set default TTL if not provided`() {
         val event = createEvent(corrId, 0L) // TTL 0
 
-
-        val before = System.currentTimeMillis()
-
-        requestCache.add(event)
-
-        val after = System.currentTimeMillis()
-
         requestCache.add(event)
 
         // Default TTL in code is 2 minutes (120000ms)
-        assertThat(event.timeToLive).isBetween(before, after + 120000L)
+        assertThat(event.timeToLive).isEqualTo(event.created + 120000L)
     }
 
     @Test


### PR DESCRIPTION
If time to live is null or not set, the default ttl (2 minutes) will be set from current timestamp