### PR TITLE
fix: use 7 day retention-time for all topics

### DIFF
--- a/src/main/java/no/fintlabs/provider/register/AdapterContractConsumer.java
+++ b/src/main/java/no/fintlabs/provider/register/AdapterContractConsumer.java
@@ -46,7 +46,6 @@ public class AdapterContractConsumer {
     }
 
     private void processEvent(ConsumerRecord<String, AdapterContract> consumerRecord) {
-        adapterRegistrationTopicService.ensureCapabilityTopics(consumerRecord.value());
         adapterContractContext.add(consumerRecord.value());
     }
 

--- a/src/main/java/no/fintlabs/provider/register/AdapterRegistrationTopicService.java
+++ b/src/main/java/no/fintlabs/provider/register/AdapterRegistrationTopicService.java
@@ -19,15 +19,15 @@ public class AdapterRegistrationTopicService {
 
     public void ensureCapabilityTopics(AdapterContract adapterContract) {
         adapterContract.getCapabilities().forEach(capability -> {
-            long retensionTime = Duration.ofDays(capability.getFullSyncIntervalInDays()).toMillis();
+            long retentionTime = Duration.ofDays(7).toMillis();
             EntityTopicNameParameters topicNameParameters = createTopicNameParameters(adapterContract.getOrgId(), capability);
 
             if (providerTopicService.topicExists(topicNameParameters)) {
-                if (providerTopicService.topicHasDifferentRetentionTime(topicNameParameters, retensionTime)) {
-                    providerTopicService.ensureTopic(topicNameParameters, retensionTime);
+                if (providerTopicService.topicHasDifferentRetentionTime(topicNameParameters, retentionTime)) {
+                    providerTopicService.ensureTopic(topicNameParameters, retentionTime);
                 }
             } else {
-                providerTopicService.ensureTopic(topicNameParameters, retensionTime);
+                providerTopicService.ensureTopic(topicNameParameters, retentionTime);
             }
         });
     }


### PR DESCRIPTION
Changes:
- 7 day retention-time for all topics
- Ensuring of topics only happens upon registration, not restart of the service