### PR TITLE
feature: add opt-in TopicCleanupService for orphaned fint-core topics

### DIFF
--- a/src/main/java/no/fintlabs/provider/config/CleanupTopicsProperties.kt
+++ b/src/main/java/no/fintlabs/provider/config/CleanupTopicsProperties.kt
@@ -1,0 +1,12 @@
+package no.fintlabs.provider.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import java.time.Duration
+
+@ConfigurationProperties(prefix = "fint.provider.cleanup-topics")
+data class CleanupTopicsProperties(
+    val enabled: Boolean = false,
+    val orgIds: List<String> = emptyList(),
+    val batchSize: Int = 10,
+    val batchDelay: Duration = Duration.ofSeconds(30),
+)

--- a/src/main/java/no/fintlabs/provider/config/CleanupTopicsProperties.kt
+++ b/src/main/java/no/fintlabs/provider/config/CleanupTopicsProperties.kt
@@ -6,7 +6,6 @@ import java.time.Duration
 @ConfigurationProperties(prefix = "fint.provider.cleanup-topics")
 data class CleanupTopicsProperties(
     val enabled: Boolean = false,
-    val orgIds: List<String> = emptyList(),
     val batchSize: Int = 10,
     val batchDelay: Duration = Duration.ofSeconds(30),
 )

--- a/src/main/java/no/fintlabs/provider/kafka/topic/TopicCleanupService.kt
+++ b/src/main/java/no/fintlabs/provider/kafka/topic/TopicCleanupService.kt
@@ -1,0 +1,210 @@
+package no.fintlabs.provider.kafka.topic
+
+import no.fintlabs.provider.config.CleanupTopicsProperties
+import no.fintlabs.provider.config.ProviderProperties
+import no.fintlabs.provider.kafka.topic.TopicNamesConstants.ADAPTER_DELETE_SYNC_EVENT_NAME
+import no.fintlabs.provider.kafka.topic.TopicNamesConstants.ADAPTER_DELTA_SYNC_EVENT_NAME
+import no.fintlabs.provider.kafka.topic.TopicNamesConstants.ADAPTER_FULL_SYNC_EVENT_NAME
+import no.fintlabs.provider.kafka.topic.TopicNamesConstants.ADAPTER_REGISTER_EVENT_NAME
+import no.fintlabs.provider.kafka.topic.TopicNamesConstants.CONSUMER_ERROR_EVENT_NAME
+import no.fintlabs.provider.kafka.topic.TopicNamesConstants.FINT_CORE
+import no.fintlabs.provider.kafka.topic.TopicNamesConstants.HEARTBEAT_EVENT_NAME
+import no.fintlabs.provider.kafka.topic.TopicNamesConstants.SYNC_STATUS_EVENT_NAME
+import no.novari.kafka.topic.name.EntityTopicNameParameters
+import no.novari.kafka.topic.name.EventTopicNameParameters
+import no.novari.kafka.topic.name.TopicNamePrefixParameters
+import no.novari.kafka.topic.name.TopicNameService
+import org.apache.kafka.clients.admin.AdminClient
+import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.context.event.ApplicationReadyEvent
+import org.springframework.context.event.EventListener
+import org.springframework.kafka.core.KafkaAdmin
+import org.springframework.stereotype.Component
+import java.time.Duration
+
+@Component
+@ConditionalOnProperty(prefix = "fint.provider.cleanup-topics", name = ["enabled"], havingValue = "true")
+class TopicCleanupService(
+    private val providerProperties: ProviderProperties,
+    private val cleanupTopicsProperties: CleanupTopicsProperties,
+    private val topicNameService: TopicNameService,
+    private val kafkaAdmin: KafkaAdmin,
+) {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    /**
+     * Startup hook: opens an [AdminClient] against the configured Kafka cluster and runs
+     * a single cleanup pass, closing the client when the pass finishes.
+     */
+    @EventListener(ApplicationReadyEvent::class)
+    fun cleanupOnStartup() {
+        AdminClient.create(kafkaAdmin.configurationProperties).use { cleanup(it) }
+    }
+
+    /**
+     * Runs one cleanup pass against [adminClient]:
+     *  1. Returns early when no org-ids are configured — cleanup is opt-in per org.
+     *  2. Builds the "keep" set via [computeExpectedTopicNames].
+     *  3. Lists every topic currently on the broker.
+     *  4. Collects orphan topics per configured org via [collectOrphansToDelete].
+     *  5. If any orphans are found, deletes them in paced batches.
+     *
+     * @return the set of topics that were actually deleted (empty if there was nothing to do).
+     */
+    fun cleanup(adminClient: AdminClient): Set<String> {
+        if (cleanupTopicsProperties.orgIds.isEmpty()) {
+            logger.info("No org-ids configured under 'fint.provider.cleanup-topics' — nothing to do")
+            return emptySet()
+        }
+
+        val expected = computeExpectedTopicNames()
+        val existing = adminClient.listTopics().names().get()
+
+        val toDelete = collectOrphansToDelete(existing, expected)
+        if (toDelete.isEmpty()) return emptySet()
+
+        deleteInBatches(adminClient, toDelete)
+        return toDelete
+    }
+
+    /**
+     * Walks each configured org and gathers the topics that should be removed. A topic is
+     * considered an orphan when it starts with `<orgId>.`, contains `fint-core`, and is
+     * absent from [expected]. Non-fint-core topics and topics belonging to orgs that are
+     * not in the cleanup config are never included.
+     */
+    private fun collectOrphansToDelete(existing: Set<String>, expected: Set<String>): Set<String> {
+        val toDelete = mutableSetOf<String>()
+        cleanupTopicsProperties.orgIds.forEach { orgId ->
+            val orphansForOrg = findOrphans(existing, orgId, expected)
+            if (orphansForOrg.isEmpty()) {
+                logger.info("No obsolete '{}' topics for org '{}'", FINT_CORE, orgId)
+            } else {
+                logger.warn(
+                    "Org '{}': deleting {} obsolete topic(s): {}",
+                    orgId, orphansForOrg.size, orphansForOrg
+                )
+                toDelete += orphansForOrg
+            }
+        }
+        return toDelete
+    }
+
+    /**
+     * Filters [existing] to topics that belong to [orgId] (exact `<orgId>.` prefix), contain
+     * `fint-core`, and are not in the [expected] keep-set.
+     */
+    private fun findOrphans(existing: Set<String>, orgId: String, expected: Set<String>): Set<String> =
+        existing
+            .filter { it.startsWith("$orgId.") && it.contains(FINT_CORE) }
+            .filterNot(expected::contains)
+            .toSet()
+
+    /**
+     * Splits [toDelete] into chunks of `batchSize` and issues one `deleteTopics` call per
+     * chunk, pausing [CleanupTopicsProperties.batchDelay] between chunks so the broker is
+     * never overwhelmed. No pause follows the final batch.
+     */
+    private fun deleteInBatches(adminClient: AdminClient, toDelete: Set<String>) {
+        val batchSize = cleanupTopicsProperties.batchSize.coerceAtLeast(1)
+        val batches = toDelete.chunked(batchSize)
+        val total = toDelete.size
+        var deleted = 0
+        batches.forEachIndexed { index, batch ->
+            adminClient.deleteTopics(batch).all().get()
+            deleted += batch.size
+            logger.info(
+                "Batch {}/{} done — {}/{} topic(s) deleted",
+                index + 1, batches.size, deleted, total
+            )
+            if (index < batches.lastIndex) pauseBetweenBatches()
+        }
+    }
+
+    private fun pauseBetweenBatches() {
+        val delay = cleanupTopicsProperties.batchDelay
+        if (delay > Duration.ZERO) Thread.sleep(delay.toMillis())
+    }
+
+    /**
+     * Builds the full set of topic names the gateway is expected to own. These topics are
+     * never deleted by the cleanup pass, even when they match the `fint-core` filter.
+     *
+     * The set contains, for every `(component, orgId)` pair in `components.yaml`:
+     *  - the entity topic (`<orgId>.fint-core.entity.<domain>-<package>`)
+     *  - the request event topic (`<orgId>.fint-core.event.<domain>-<package>-request`)
+     *  - the response event topic (`<orgId>.fint-core.event.<domain>-<package>-response`)
+     *  - the relation-update topic — only when the component has `relation-update: true`
+     *
+     * It also contains the seven global event topics under the application-default orgId:
+     * `adapter-health`, `adapter-register`, `adapter-full-sync`, `adapter-delta-sync`,
+     * `adapter-delete-sync`, `consumer-error`, `sync-status`.
+     */
+    fun computeExpectedTopicNames(): Set<String> {
+        val expected = mutableSetOf<String>()
+
+        providerProperties.components.forEach { component ->
+            val componentName = "${component.domainName}-${component.packageName}"
+            component.orgIds.forEach { orgId ->
+                expected += entityTopicName(orgId, componentName) // Resource entity topic
+                expected += eventTopicName(orgId, "$componentName-request") // Event request topic
+                expected += eventTopicName(orgId, "$componentName-response") // Event response topic
+                if (component.relationUpdate) {
+                    expected += entityTopicName(orgId, "$componentName-relation-update")
+                }
+            }
+        }
+
+        listOf(
+            HEARTBEAT_EVENT_NAME,
+            ADAPTER_REGISTER_EVENT_NAME,
+            ADAPTER_FULL_SYNC_EVENT_NAME,
+            ADAPTER_DELTA_SYNC_EVENT_NAME,
+            ADAPTER_DELETE_SYNC_EVENT_NAME,
+            CONSUMER_ERROR_EVENT_NAME,
+            SYNC_STATUS_EVENT_NAME,
+        ).forEach { eventName ->
+            expected += topicNameService.validateAndMapToTopicName(
+                EventTopicNameParameters.builder()
+                    .topicNamePrefixParameters(
+                        TopicNamePrefixParameters.stepBuilder()
+                            .orgIdApplicationDefault()
+                            .domainContextApplicationDefault()
+                            .build()
+                    )
+                    .eventName(eventName)
+                    .build()
+            )
+        }
+
+        return expected
+    }
+
+    private fun entityTopicName(orgId: String, resourceName: String): String =
+        topicNameService.validateAndMapToTopicName(
+            EntityTopicNameParameters.builder()
+                .topicNamePrefixParameters(
+                    TopicNamePrefixParameters.stepBuilder()
+                        .orgId(orgId)
+                        .domainContextApplicationDefault()
+                        .build()
+                )
+                .resourceName(resourceName)
+                .build()
+        )
+
+    private fun eventTopicName(orgId: String, eventName: String): String =
+        topicNameService.validateAndMapToTopicName(
+            EventTopicNameParameters.builder()
+                .topicNamePrefixParameters(
+                    TopicNamePrefixParameters.stepBuilder()
+                        .orgId(orgId)
+                        .domainContextApplicationDefault()
+                        .build()
+                )
+                .eventName(eventName)
+                .build()
+        )
+}

--- a/src/main/java/no/fintlabs/provider/kafka/topic/TopicCleanupService.kt
+++ b/src/main/java/no/fintlabs/provider/kafka/topic/TopicCleanupService.kt
@@ -45,24 +45,26 @@ class TopicCleanupService(
 
     /**
      * Runs one cleanup pass against [adminClient]:
-     *  1. Returns early when no org-ids are configured — cleanup is opt-in per org.
+     *  1. Derives the orgs to scan from the distinct orgIds in `components.yaml` — returns
+     *     early when no components are configured.
      *  2. Builds the "keep" set via [computeExpectedTopicNames].
      *  3. Lists every topic currently on the broker.
-     *  4. Collects orphan topics per configured org via [collectOrphansToDelete].
+     *  4. Collects orphan topics per derived org via [collectOrphansToDelete].
      *  5. If any orphans are found, deletes them in paced batches.
      *
      * @return the set of topics that were actually deleted (empty if there was nothing to do).
      */
     fun cleanup(adminClient: AdminClient): Set<String> {
-        if (cleanupTopicsProperties.orgIds.isEmpty()) {
-            logger.info("No org-ids configured under 'fint.provider.cleanup-topics' — nothing to do")
+        val scopedOrgIds = providerProperties.components.flatMap { it.orgIds }.toSet()
+        if (scopedOrgIds.isEmpty()) {
+            logger.info("No orgIds derived from components.yaml — nothing to do")
             return emptySet()
         }
 
         val expected = computeExpectedTopicNames()
         val existing = adminClient.listTopics().names().get()
 
-        val toDelete = collectOrphansToDelete(existing, expected)
+        val toDelete = collectOrphansToDelete(existing, expected, scopedOrgIds)
         if (toDelete.isEmpty()) return emptySet()
 
         deleteInBatches(adminClient, toDelete)
@@ -70,14 +72,18 @@ class TopicCleanupService(
     }
 
     /**
-     * Walks each configured org and gathers the topics that should be removed. A topic is
-     * considered an orphan when it starts with `<orgId>.`, contains `fint-core`, and is
-     * absent from [expected]. Non-fint-core topics and topics belonging to orgs that are
-     * not in the cleanup config are never included.
+     * Walks each org derived from `components.yaml` and gathers the topics that should be
+     * removed. A topic is considered an orphan when it starts with `<orgId>.`, contains
+     * `fint-core`, and is absent from [expected]. Non-fint-core topics and topics belonging
+     * to orgs that are not in [scopedOrgIds] are never included.
      */
-    private fun collectOrphansToDelete(existing: Set<String>, expected: Set<String>): Set<String> {
+    private fun collectOrphansToDelete(
+        existing: Set<String>,
+        expected: Set<String>,
+        scopedOrgIds: Set<String>,
+    ): Set<String> {
         val toDelete = mutableSetOf<String>()
-        cleanupTopicsProperties.orgIds.forEach { orgId ->
+        scopedOrgIds.forEach { orgId ->
             val orphansForOrg = findOrphans(existing, orgId, expected)
             if (orphansForOrg.isEmpty()) {
                 logger.info("No obsolete '{}' topics for org '{}'", FINT_CORE, orgId)

--- a/src/main/java/no/fintlabs/provider/kafka/topic/TopicNamesConstants.kt
+++ b/src/main/java/no/fintlabs/provider/kafka/topic/TopicNamesConstants.kt
@@ -15,4 +15,7 @@ object TopicNamesConstants {
     const val ADAPTER_FULL_SYNC_EVENT_NAME = "adapter-full-sync"
     const val ADAPTER_DELTA_SYNC_EVENT_NAME = "adapter-delta-sync"
     const val ADAPTER_DELETE_SYNC_EVENT_NAME = "adapter-delete-sync"
+
+    const val CONSUMER_ERROR_EVENT_NAME = "consumer-error"
+    const val SYNC_STATUS_EVENT_NAME = "sync-status"
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -26,7 +26,9 @@ novari:
 
 spring:
   config:
-    import: classpath:components.yaml
+    import:
+      - classpath:components.yaml
+      - classpath:cleanup-topics.yaml
   threads:
     virtual:
       enabled: true

--- a/src/main/resources/cleanup-topics.yaml
+++ b/src/main/resources/cleanup-topics.yaml
@@ -1,0 +1,7 @@
+fint:
+  provider:
+    cleanup-topics:
+      enabled: false
+      batch-size: 10
+      batch-delay: 30s
+      org-ids: []

--- a/src/main/resources/cleanup-topics.yaml
+++ b/src/main/resources/cleanup-topics.yaml
@@ -4,4 +4,3 @@ fint:
       enabled: false
       batch-size: 10
       batch-delay: 30s
-      org-ids: []

--- a/src/test/kotlin/no/fintlabs/provider/topic/TopicCleanupServiceTest.kt
+++ b/src/test/kotlin/no/fintlabs/provider/topic/TopicCleanupServiceTest.kt
@@ -49,14 +49,12 @@ class TopicCleanupServiceTest {
 
     private fun topicCleanupService(
         components: List<ComponentConfig> = emptyList(),
-        cleanupOrgIds: List<String> = emptyList(),
         batchSize: Int = 10,
         batchDelay: Duration = Duration.ZERO,
     ) = TopicCleanupService(
         ProviderProperties(components = components),
         CleanupTopicsProperties(
             enabled = true,
-            orgIds = cleanupOrgIds,
             batchSize = batchSize,
             batchDelay = batchDelay,
         ),
@@ -152,8 +150,8 @@ class TopicCleanupServiceTest {
     }
 
     @Test
-    fun `cleanup does nothing and skips listing when cleanup org-ids is empty`() {
-        val deleted = topicCleanupService(cleanupOrgIds = emptyList()).cleanup(adminClient)
+    fun `cleanup does nothing and skips listing when components are empty`() {
+        val deleted = topicCleanupService().cleanup(adminClient)
 
         assertThat(deleted).isEmpty()
         verify(exactly = 0) { adminClient.listTopics() }
@@ -161,8 +159,8 @@ class TopicCleanupServiceTest {
     }
 
     @Test
-    fun `cleanup only deletes topics belonging to orgs listed in cleanup config`() {
-        val components = listOf(ComponentConfig("utdanning", "elev", listOf("afk-no", "bfk-no")))
+    fun `cleanup only deletes topics belonging to orgs derived from components`() {
+        val components = listOf(ComponentConfig("utdanning", "elev", listOf("afk-no")))
         val afkOrphan = "afk-no.fint-core.entity.utdanning-obsolete"
         val bfkOrphan = "bfk-no.fint-core.entity.utdanning-obsolete"
 
@@ -171,12 +169,11 @@ class TopicCleanupServiceTest {
                 afkOrphan,
                 bfkOrphan,
                 "afk-no.fint-core.entity.utdanning-elev",
-                "bfk-no.fint-core.entity.utdanning-elev",
             )
         )
         stubDeleteTopics()
 
-        val deleted = topicCleanupService(components, cleanupOrgIds = listOf("afk-no")).cleanup(adminClient)
+        val deleted = topicCleanupService(components).cleanup(adminClient)
 
         assertThat(deleted).containsExactly(afkOrphan)
         verify { adminClient.deleteTopics(match<Collection<String>> { it.toSet() == setOf(afkOrphan) }) }
@@ -184,13 +181,14 @@ class TopicCleanupServiceTest {
 
     @Test
     fun `cleanup requires the orgId prefix to match exactly so similar names are not swept up`() {
+        val components = listOf(ComponentConfig("utdanning", "elev", listOf("afk-no")))
         val orphan = "afk-no.fint-core.entity.something-old"
         val neighbor = "afk-nord-no.fint-core.entity.something-old"
 
-        stubListTopics(setOf(orphan, neighbor))
+        stubListTopics(setOf(orphan, neighbor, "afk-no.fint-core.entity.utdanning-elev"))
         stubDeleteTopics()
 
-        val deleted = topicCleanupService(cleanupOrgIds = listOf("afk-no")).cleanup(adminClient)
+        val deleted = topicCleanupService(components).cleanup(adminClient)
 
         assertThat(deleted).containsExactly(orphan)
         assertThat(deleted).doesNotContain(neighbor)
@@ -198,12 +196,13 @@ class TopicCleanupServiceTest {
 
     @Test
     fun `cleanup ignores topics that do not contain fint-core even within the org scope`() {
+        val components = listOf(ComponentConfig("utdanning", "elev", listOf("afk-no")))
         val foreign = "afk-no.fint-example.entity.some-topic"
         val system = "__consumer_offsets"
 
-        stubListTopics(setOf(foreign, system))
+        stubListTopics(setOf(foreign, system, "afk-no.fint-core.entity.utdanning-elev"))
 
-        val deleted = topicCleanupService(cleanupOrgIds = listOf("afk-no")).cleanup(adminClient)
+        val deleted = topicCleanupService(components).cleanup(adminClient)
 
         assertThat(deleted).isEmpty()
         verify(exactly = 0) { adminClient.deleteTopics(any<Collection<String>>()) }
@@ -222,7 +221,7 @@ class TopicCleanupServiceTest {
             )
         )
 
-        val deleted = topicCleanupService(components, cleanupOrgIds = listOf("afk-no")).cleanup(adminClient)
+        val deleted = topicCleanupService(components).cleanup(adminClient)
 
         assertThat(deleted).isEmpty()
         verify(exactly = 0) { adminClient.deleteTopics(any<Collection<String>>()) }
@@ -242,7 +241,7 @@ class TopicCleanupServiceTest {
         stubListTopics(setOf(afkOrphan, bfkOrphan, nonFintCore, keptAfk, keptBfk))
         stubDeleteTopics()
 
-        val deleted = topicCleanupService(components, cleanupOrgIds = listOf("afk-no", "bfk-no")).cleanup(adminClient)
+        val deleted = topicCleanupService(components).cleanup(adminClient)
 
         assertThat(deleted).containsExactlyInAnyOrder(afkOrphan, bfkOrphan)
         verify {
@@ -253,10 +252,11 @@ class TopicCleanupServiceTest {
     }
 
     @Test
-    fun `cleanup returns empty when Kafka reports no topics for configured orgs`() {
+    fun `cleanup returns empty when Kafka reports no topics for derived orgs`() {
+        val components = listOf(ComponentConfig("utdanning", "elev", listOf("afk-no")))
         stubListTopics(emptySet())
 
-        val deleted = topicCleanupService(cleanupOrgIds = listOf("afk-no")).cleanup(adminClient)
+        val deleted = topicCleanupService(components).cleanup(adminClient)
 
         assertThat(deleted).isEmpty()
         verify(exactly = 0) { adminClient.deleteTopics(any<Collection<String>>()) }
@@ -273,21 +273,19 @@ class TopicCleanupServiceTest {
         stubListTopics(setOf(keptEntity, staleRelationUpdate))
         stubDeleteTopics()
 
-        val deleted = topicCleanupService(components, cleanupOrgIds = listOf("afk-no")).cleanup(adminClient)
+        val deleted = topicCleanupService(components).cleanup(adminClient)
 
         assertThat(deleted).containsExactly(staleRelationUpdate)
     }
 
     @Test
     fun `cleanup splits deletes into batches when orphans exceed batch size`() {
+        val components = listOf(ComponentConfig("utdanning", "elev", listOf("afk-no")))
         val orphans = (1..7).map { "afk-no.fint-core.entity.utdanning-old-$it" }.toSet()
         stubListTopics(orphans)
         stubDeleteTopics()
 
-        val deleted = topicCleanupService(
-            cleanupOrgIds = listOf("afk-no"),
-            batchSize = 3,
-        ).cleanup(adminClient)
+        val deleted = topicCleanupService(components, batchSize = 3).cleanup(adminClient)
 
         assertThat(deleted).containsExactlyInAnyOrderElementsOf(orphans)
         verify(exactly = 3) { adminClient.deleteTopics(any<Collection<String>>()) }
@@ -295,6 +293,7 @@ class TopicCleanupServiceTest {
 
     @Test
     fun `cleanup partitions orphans across batches so every orphan is deleted exactly once`() {
+        val components = listOf(ComponentConfig("utdanning", "elev", listOf("afk-no")))
         val orphans = (1..5).map { "afk-no.fint-core.entity.utdanning-old-$it" }.toSet()
         stubListTopics(orphans)
         val seenBatches = mutableListOf<Collection<String>>()
@@ -302,10 +301,7 @@ class TopicCleanupServiceTest {
         every { adminClient.deleteTopics(capture(seenBatches)) } returns deleteResult
         every { deleteResult.all() } returns KafkaFuture.completedFuture(null)
 
-        topicCleanupService(
-            cleanupOrgIds = listOf("afk-no"),
-            batchSize = 2,
-        ).cleanup(adminClient)
+        topicCleanupService(components, batchSize = 2).cleanup(adminClient)
 
         assertThat(seenBatches).hasSize(3)
         assertThat(seenBatches.map { it.size }).containsExactly(2, 2, 1)
@@ -314,17 +310,15 @@ class TopicCleanupServiceTest {
 
     @Test
     fun `cleanup makes a single delete call when orphans fit within one batch`() {
+        val components = listOf(ComponentConfig("utdanning", "elev", listOf("afk-no")))
         val orphans = setOf(
             "afk-no.fint-core.entity.utdanning-old-1",
             "afk-no.fint-core.entity.utdanning-old-2",
         )
-        stubListTopics(orphans)
+        stubListTopics(orphans + "afk-no.fint-core.entity.utdanning-elev")
         stubDeleteTopics()
 
-        topicCleanupService(
-            cleanupOrgIds = listOf("afk-no"),
-            batchSize = 10,
-        ).cleanup(adminClient)
+        topicCleanupService(components, batchSize = 10).cleanup(adminClient)
 
         verify(exactly = 1) { adminClient.deleteTopics(any<Collection<String>>()) }
     }

--- a/src/test/kotlin/no/fintlabs/provider/topic/TopicCleanupServiceTest.kt
+++ b/src/test/kotlin/no/fintlabs/provider/topic/TopicCleanupServiceTest.kt
@@ -1,0 +1,331 @@
+package no.fintlabs.provider.topic
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import no.fintlabs.provider.config.CleanupTopicsProperties
+import no.fintlabs.provider.config.ComponentConfig
+import no.fintlabs.provider.config.ProviderProperties
+import no.fintlabs.provider.kafka.topic.TopicCleanupService
+import no.novari.kafka.topic.name.EntityTopicNameParameters
+import no.novari.kafka.topic.name.EventTopicNameParameters
+import no.novari.kafka.topic.name.TopicNameParameters
+import no.novari.kafka.topic.name.TopicNameService
+import org.apache.kafka.clients.admin.AdminClient
+import org.apache.kafka.clients.admin.DeleteTopicsResult
+import org.apache.kafka.clients.admin.ListTopicsResult
+import org.apache.kafka.common.KafkaFuture
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.kafka.core.KafkaAdmin
+import java.time.Duration
+
+class TopicCleanupServiceTest {
+
+    private lateinit var topicNameService: TopicNameService
+    private lateinit var kafkaAdmin: KafkaAdmin
+    private lateinit var adminClient: AdminClient
+
+    private val defaultOrgId = "fintlabs-no"
+    private val defaultDomainContext = "fint-core"
+
+    @BeforeEach
+    fun setup() {
+        topicNameService = mockk()
+        kafkaAdmin = mockk(relaxed = true)
+        adminClient = mockk(relaxed = true)
+
+        every { topicNameService.validateAndMapToTopicName(any()) } answers {
+            val params = firstArg<TopicNameParameters>()
+            val orgId = params.topicNamePrefixParameters.orgId ?: defaultOrgId
+            val domainContext = params.topicNamePrefixParameters.domainContext ?: defaultDomainContext
+            val suffix = params.topicNameSuffixParameters
+                .mapNotNull { it.value }
+                .joinToString(".")
+            "$orgId.$domainContext.${params.messageType.topicNameParameter}.$suffix"
+        }
+    }
+
+    private fun topicCleanupService(
+        components: List<ComponentConfig> = emptyList(),
+        cleanupOrgIds: List<String> = emptyList(),
+        batchSize: Int = 10,
+        batchDelay: Duration = Duration.ZERO,
+    ) = TopicCleanupService(
+        ProviderProperties(components = components),
+        CleanupTopicsProperties(
+            enabled = true,
+            orgIds = cleanupOrgIds,
+            batchSize = batchSize,
+            batchDelay = batchDelay,
+        ),
+        topicNameService,
+        kafkaAdmin,
+    )
+
+    private fun stubListTopics(topics: Set<String>) {
+        val listResult = mockk<ListTopicsResult>()
+        every { adminClient.listTopics() } returns listResult
+        every { listResult.names() } returns KafkaFuture.completedFuture(topics)
+    }
+
+    private fun stubDeleteTopics(): DeleteTopicsResult {
+        val deleteResult = mockk<DeleteTopicsResult>()
+        every { adminClient.deleteTopics(any<Collection<String>>()) } returns deleteResult
+        every { deleteResult.all() } returns KafkaFuture.completedFuture(null)
+        return deleteResult
+    }
+
+    @Test
+    fun `computeExpectedTopicNames produces entity, request and response topics per component-org pair`() {
+        val components = listOf(
+            ComponentConfig("utdanning", "elev", listOf("afk-no", "bfk-no"))
+        )
+
+        val expected = topicCleanupService(components).computeExpectedTopicNames()
+
+        assertThat(expected).contains(
+            "afk-no.fint-core.entity.utdanning-elev",
+            "afk-no.fint-core.event.utdanning-elev-request",
+            "afk-no.fint-core.event.utdanning-elev-response",
+            "bfk-no.fint-core.entity.utdanning-elev",
+            "bfk-no.fint-core.event.utdanning-elev-request",
+            "bfk-no.fint-core.event.utdanning-elev-response",
+        )
+    }
+
+    @Test
+    fun `computeExpectedTopicNames includes relation-update topic only when component has the flag set`() {
+        val components = listOf(
+            ComponentConfig("utdanning", "elev", listOf("afk-no"), relationUpdate = true),
+            ComponentConfig("utdanning", "ot", listOf("afk-no"), relationUpdate = false),
+        )
+
+        val expected = topicCleanupService(components).computeExpectedTopicNames()
+
+        assertThat(expected).contains("afk-no.fint-core.entity.utdanning-elev-relation-update")
+        assertThat(expected).doesNotContain("afk-no.fint-core.entity.utdanning-ot-relation-update")
+    }
+
+    @Test
+    fun `computeExpectedTopicNames always includes the global event topics`() {
+        val expected = topicCleanupService().computeExpectedTopicNames()
+
+        assertThat(expected).contains(
+            "$defaultOrgId.$defaultDomainContext.event.adapter-health",
+            "$defaultOrgId.$defaultDomainContext.event.adapter-register",
+            "$defaultOrgId.$defaultDomainContext.event.adapter-full-sync",
+            "$defaultOrgId.$defaultDomainContext.event.adapter-delta-sync",
+            "$defaultOrgId.$defaultDomainContext.event.adapter-delete-sync",
+            "$defaultOrgId.$defaultDomainContext.event.consumer-error",
+            "$defaultOrgId.$defaultDomainContext.event.sync-status",
+        )
+    }
+
+    @Test
+    fun `computeExpectedTopicNames uses correct parameters for entity and event builders`() {
+        val components = listOf(
+            ComponentConfig("utdanning", "elev", listOf("afk-no"), relationUpdate = true)
+        )
+
+        topicCleanupService(components).computeExpectedTopicNames()
+
+        verify {
+            topicNameService.validateAndMapToTopicName(match<EntityTopicNameParameters> {
+                it.resourceName == "utdanning-elev" &&
+                        it.topicNamePrefixParameters.orgId == "afk-no"
+            })
+            topicNameService.validateAndMapToTopicName(match<EntityTopicNameParameters> {
+                it.resourceName == "utdanning-elev-relation-update" &&
+                        it.topicNamePrefixParameters.orgId == "afk-no"
+            })
+            topicNameService.validateAndMapToTopicName(match<EventTopicNameParameters> {
+                it.eventName == "utdanning-elev-request" &&
+                        it.topicNamePrefixParameters.orgId == "afk-no"
+            })
+            topicNameService.validateAndMapToTopicName(match<EventTopicNameParameters> {
+                it.eventName == "utdanning-elev-response" &&
+                        it.topicNamePrefixParameters.orgId == "afk-no"
+            })
+        }
+    }
+
+    @Test
+    fun `cleanup does nothing and skips listing when cleanup org-ids is empty`() {
+        val deleted = topicCleanupService(cleanupOrgIds = emptyList()).cleanup(adminClient)
+
+        assertThat(deleted).isEmpty()
+        verify(exactly = 0) { adminClient.listTopics() }
+        verify(exactly = 0) { adminClient.deleteTopics(any<Collection<String>>()) }
+    }
+
+    @Test
+    fun `cleanup only deletes topics belonging to orgs listed in cleanup config`() {
+        val components = listOf(ComponentConfig("utdanning", "elev", listOf("afk-no", "bfk-no")))
+        val afkOrphan = "afk-no.fint-core.entity.utdanning-obsolete"
+        val bfkOrphan = "bfk-no.fint-core.entity.utdanning-obsolete"
+
+        stubListTopics(
+            setOf(
+                afkOrphan,
+                bfkOrphan,
+                "afk-no.fint-core.entity.utdanning-elev",
+                "bfk-no.fint-core.entity.utdanning-elev",
+            )
+        )
+        stubDeleteTopics()
+
+        val deleted = topicCleanupService(components, cleanupOrgIds = listOf("afk-no")).cleanup(adminClient)
+
+        assertThat(deleted).containsExactly(afkOrphan)
+        verify { adminClient.deleteTopics(match<Collection<String>> { it.toSet() == setOf(afkOrphan) }) }
+    }
+
+    @Test
+    fun `cleanup requires the orgId prefix to match exactly so similar names are not swept up`() {
+        val orphan = "afk-no.fint-core.entity.something-old"
+        val neighbor = "afk-nord-no.fint-core.entity.something-old"
+
+        stubListTopics(setOf(orphan, neighbor))
+        stubDeleteTopics()
+
+        val deleted = topicCleanupService(cleanupOrgIds = listOf("afk-no")).cleanup(adminClient)
+
+        assertThat(deleted).containsExactly(orphan)
+        assertThat(deleted).doesNotContain(neighbor)
+    }
+
+    @Test
+    fun `cleanup ignores topics that do not contain fint-core even within the org scope`() {
+        val foreign = "afk-no.fint-example.entity.some-topic"
+        val system = "__consumer_offsets"
+
+        stubListTopics(setOf(foreign, system))
+
+        val deleted = topicCleanupService(cleanupOrgIds = listOf("afk-no")).cleanup(adminClient)
+
+        assertThat(deleted).isEmpty()
+        verify(exactly = 0) { adminClient.deleteTopics(any<Collection<String>>()) }
+    }
+
+    @Test
+    fun `cleanup does not call deleteTopics when every fint-core topic in scope is expected`() {
+        val components = listOf(ComponentConfig("utdanning", "elev", listOf("afk-no")))
+
+        stubListTopics(
+            setOf(
+                "afk-no.fint-core.entity.utdanning-elev",
+                "afk-no.fint-core.event.utdanning-elev-request",
+                "afk-no.fint-core.event.utdanning-elev-response",
+                "__consumer_offsets",
+            )
+        )
+
+        val deleted = topicCleanupService(components, cleanupOrgIds = listOf("afk-no")).cleanup(adminClient)
+
+        assertThat(deleted).isEmpty()
+        verify(exactly = 0) { adminClient.deleteTopics(any<Collection<String>>()) }
+    }
+
+    @Test
+    fun `cleanup aggregates orphans across multiple orgs into a single delete call`() {
+        val components = listOf(
+            ComponentConfig("utdanning", "elev", listOf("afk-no", "bfk-no"), relationUpdate = true)
+        )
+        val afkOrphan = "afk-no.fint-core.entity.utdanning-removed"
+        val bfkOrphan = "bfk-no.fint-core.event.utdanning-elev-legacy-response"
+        val nonFintCore = "afk-no.something-else.entity.stuff"
+        val keptAfk = "afk-no.fint-core.entity.utdanning-elev"
+        val keptBfk = "bfk-no.fint-core.entity.utdanning-elev-relation-update"
+
+        stubListTopics(setOf(afkOrphan, bfkOrphan, nonFintCore, keptAfk, keptBfk))
+        stubDeleteTopics()
+
+        val deleted = topicCleanupService(components, cleanupOrgIds = listOf("afk-no", "bfk-no")).cleanup(adminClient)
+
+        assertThat(deleted).containsExactlyInAnyOrder(afkOrphan, bfkOrphan)
+        verify {
+            adminClient.deleteTopics(match<Collection<String>> {
+                it.toSet() == setOf(afkOrphan, bfkOrphan)
+            })
+        }
+    }
+
+    @Test
+    fun `cleanup returns empty when Kafka reports no topics for configured orgs`() {
+        stubListTopics(emptySet())
+
+        val deleted = topicCleanupService(cleanupOrgIds = listOf("afk-no")).cleanup(adminClient)
+
+        assertThat(deleted).isEmpty()
+        verify(exactly = 0) { adminClient.deleteTopics(any<Collection<String>>()) }
+    }
+
+    @Test
+    fun `cleanup deletes an existing relation-update topic when the component flag is false`() {
+        val components = listOf(
+            ComponentConfig("utdanning", "elev", listOf("afk-no"), relationUpdate = false)
+        )
+        val staleRelationUpdate = "afk-no.fint-core.entity.utdanning-elev-relation-update"
+        val keptEntity = "afk-no.fint-core.entity.utdanning-elev"
+
+        stubListTopics(setOf(keptEntity, staleRelationUpdate))
+        stubDeleteTopics()
+
+        val deleted = topicCleanupService(components, cleanupOrgIds = listOf("afk-no")).cleanup(adminClient)
+
+        assertThat(deleted).containsExactly(staleRelationUpdate)
+    }
+
+    @Test
+    fun `cleanup splits deletes into batches when orphans exceed batch size`() {
+        val orphans = (1..7).map { "afk-no.fint-core.entity.utdanning-old-$it" }.toSet()
+        stubListTopics(orphans)
+        stubDeleteTopics()
+
+        val deleted = topicCleanupService(
+            cleanupOrgIds = listOf("afk-no"),
+            batchSize = 3,
+        ).cleanup(adminClient)
+
+        assertThat(deleted).containsExactlyInAnyOrderElementsOf(orphans)
+        verify(exactly = 3) { adminClient.deleteTopics(any<Collection<String>>()) }
+    }
+
+    @Test
+    fun `cleanup partitions orphans across batches so every orphan is deleted exactly once`() {
+        val orphans = (1..5).map { "afk-no.fint-core.entity.utdanning-old-$it" }.toSet()
+        stubListTopics(orphans)
+        val seenBatches = mutableListOf<Collection<String>>()
+        val deleteResult = mockk<DeleteTopicsResult>()
+        every { adminClient.deleteTopics(capture(seenBatches)) } returns deleteResult
+        every { deleteResult.all() } returns KafkaFuture.completedFuture(null)
+
+        topicCleanupService(
+            cleanupOrgIds = listOf("afk-no"),
+            batchSize = 2,
+        ).cleanup(adminClient)
+
+        assertThat(seenBatches).hasSize(3)
+        assertThat(seenBatches.map { it.size }).containsExactly(2, 2, 1)
+        assertThat(seenBatches.flatten().toSet()).isEqualTo(orphans)
+    }
+
+    @Test
+    fun `cleanup makes a single delete call when orphans fit within one batch`() {
+        val orphans = setOf(
+            "afk-no.fint-core.entity.utdanning-old-1",
+            "afk-no.fint-core.entity.utdanning-old-2",
+        )
+        stubListTopics(orphans)
+        stubDeleteTopics()
+
+        topicCleanupService(
+            cleanupOrgIds = listOf("afk-no"),
+            batchSize = 10,
+        ).cleanup(adminClient)
+
+        verify(exactly = 1) { adminClient.deleteTopics(any<Collection<String>>()) }
+    }
+}


### PR DESCRIPTION
Runs on application startup when fint.provider.cleanup-topics.enabled=true. For each configured orgId it deletes every Kafka topic that contains "fint-core" but is not in the expected set (components.yaml entity/request/ response/relation-update topics plus the global event topics). Deletions are issued in paced batches (default batch-size=10, batch-delay=30s) to avoid overwhelming the broker, with per-batch progress logging.

Also adds consumer-error and sync-status to the kept global event topics.