### PR TITLE
feat: allow per-component request/response partition override

### DIFF
--- a/src/main/java/no/fintlabs/provider/config/ProviderProperties.kt
+++ b/src/main/java/no/fintlabs/provider/config/ProviderProperties.kt
@@ -11,5 +11,7 @@ data class ComponentConfig(
     val domainName: String = "",
     val packageName: String = "",
     val orgIds: List<String> = emptyList(),
-    val relationUpdate: Boolean = false
+    val relationUpdate: Boolean = false,
+    val requestPartitions: Int? = null,
+    val responsePartitions: Int? = null
 )

--- a/src/main/java/no/fintlabs/provider/kafka/topic/RequestEventTopicEnsurer.kt
+++ b/src/main/java/no/fintlabs/provider/kafka/topic/RequestEventTopicEnsurer.kt
@@ -23,6 +23,7 @@ class RequestEventTopicEnsurer(
     @EventListener(ApplicationReadyEvent::class)
     fun ensureRequestEventTopics() {
         providerProperties.components.forEach { component ->
+            val partitions = component.requestPartitions ?: requestProducerProperties.partitions
             component.orgIds.forEach { orgId ->
                 eventTopicService.createOrModifyTopic(
                     EventTopicNameParameters.builder()
@@ -35,7 +36,7 @@ class RequestEventTopicEnsurer(
                         .eventName("${component.domainName}-${component.packageName}-request")
                         .build(),
                     EventTopicConfiguration.stepBuilder()
-                        .partitions(requestProducerProperties.partitions)
+                        .partitions(partitions)
                         .retentionTime(requestProducerProperties.retentionTime)
                         .cleanupFrequency(EventCleanupFrequency.NORMAL)
                         .build()

--- a/src/main/java/no/fintlabs/provider/kafka/topic/ResponseEventTopicEnsurer.kt
+++ b/src/main/java/no/fintlabs/provider/kafka/topic/ResponseEventTopicEnsurer.kt
@@ -23,6 +23,7 @@ class ResponseEventTopicEnsurer(
     @EventListener(ApplicationReadyEvent::class)
     fun ensureResponseEventTopics() {
         providerProperties.components.forEach { component ->
+            val partitions = component.responsePartitions ?: responseProducerProperties.partitions
             component.orgIds.forEach { orgId ->
                 eventTopicService.createOrModifyTopic(
                     EventTopicNameParameters.builder()
@@ -35,7 +36,7 @@ class ResponseEventTopicEnsurer(
                         .eventName("${component.domainName}-${component.packageName}-response")
                         .build(),
                     EventTopicConfiguration.stepBuilder()
-                        .partitions(responseProducerProperties.partitions)
+                        .partitions(partitions)
                         .retentionTime(responseProducerProperties.retentionTime)
                         .cleanupFrequency(EventCleanupFrequency.NORMAL)
                         .build()

--- a/src/test/kotlin/no/fintlabs/provider/topic/RequestEventTopicEnsurerTest.kt
+++ b/src/test/kotlin/no/fintlabs/provider/topic/RequestEventTopicEnsurerTest.kt
@@ -4,14 +4,17 @@ import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
 import no.fintlabs.provider.config.ComponentConfig
 import no.fintlabs.provider.config.ProducerProperties
 import no.fintlabs.provider.config.ProviderProperties
 import no.fintlabs.provider.kafka.topic.RequestEventTopicEnsurer
 import no.novari.kafka.topic.EventTopicService
+import no.novari.kafka.topic.configuration.EventTopicConfiguration
 import no.novari.kafka.topic.name.EventTopicNameParameters
 import no.novari.kafka.topic.name.TopicNamePrefixParameters
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -71,5 +74,31 @@ class RequestEventTopicEnsurerTest {
         sut(emptyList()).ensureRequestEventTopics()
 
         verify(exactly = 0) { eventTopicService.createOrModifyTopic(any(), any()) }
+    }
+
+    @Test
+    fun `ensureRequestEventTopics uses component requestPartitions override when set`() {
+        val components = listOf(
+            ComponentConfig(domainName = "utdanning", "elev", listOf("fintlabs-no"), requestPartitions = 5)
+        )
+        val configSlot = slot<EventTopicConfiguration>()
+        every { eventTopicService.createOrModifyTopic(any(), capture(configSlot)) } just Runs
+
+        sut(components).ensureRequestEventTopics()
+
+        assertEquals(5, configSlot.captured.partitions)
+    }
+
+    @Test
+    fun `ensureRequestEventTopics falls back to global default when requestPartitions is unset`() {
+        val components = listOf(
+            ComponentConfig(domainName = "utdanning", "elev", listOf("fintlabs-no"))
+        )
+        val configSlot = slot<EventTopicConfiguration>()
+        every { eventTopicService.createOrModifyTopic(any(), capture(configSlot)) } just Runs
+
+        sut(components).ensureRequestEventTopics()
+
+        assertEquals(requestProducerProperties.partitions, configSlot.captured.partitions)
     }
 }

--- a/src/test/kotlin/no/fintlabs/provider/topic/ResponseEventTopicEnsurerTest.kt
+++ b/src/test/kotlin/no/fintlabs/provider/topic/ResponseEventTopicEnsurerTest.kt
@@ -4,14 +4,17 @@ import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
 import no.fintlabs.provider.config.ComponentConfig
 import no.fintlabs.provider.config.ProducerProperties
 import no.fintlabs.provider.config.ProviderProperties
 import no.fintlabs.provider.kafka.topic.ResponseEventTopicEnsurer
 import no.novari.kafka.topic.EventTopicService
+import no.novari.kafka.topic.configuration.EventTopicConfiguration
 import no.novari.kafka.topic.name.EventTopicNameParameters
 import no.novari.kafka.topic.name.TopicNamePrefixParameters
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -71,5 +74,31 @@ class ResponseEventTopicEnsurerTest {
         sut(emptyList()).ensureResponseEventTopics()
 
         verify(exactly = 0) { eventTopicService.createOrModifyTopic(any(), any()) }
+    }
+
+    @Test
+    fun `ensureResponseEventTopics uses component responsePartitions override when set`() {
+        val components = listOf(
+            ComponentConfig(domainName = "utdanning", "elev", listOf("fintlabs-no"), responsePartitions = 3)
+        )
+        val configSlot = slot<EventTopicConfiguration>()
+        every { eventTopicService.createOrModifyTopic(any(), capture(configSlot)) } just Runs
+
+        sut(components).ensureResponseEventTopics()
+
+        assertEquals(3, configSlot.captured.partitions)
+    }
+
+    @Test
+    fun `ensureResponseEventTopics falls back to global default when responsePartitions is unset`() {
+        val components = listOf(
+            ComponentConfig(domainName = "utdanning", "elev", listOf("fintlabs-no"))
+        )
+        val configSlot = slot<EventTopicConfiguration>()
+        every { eventTopicService.createOrModifyTopic(any(), capture(configSlot)) } just Runs
+
+        sut(components).ensureResponseEventTopics()
+
+        assertEquals(responseProducerProperties.partitions, configSlot.captured.partitions)
     }
 }


### PR DESCRIPTION
Add optional requestPartitions and responsePartitions fields to ComponentConfig. When set, they override the global default from KafkaProperties.event.requestProducer/responseProducer; unset fields fall back to the global default.