### PR TITLE
refactor(security): migrate to fint-core-principal 4.1 and move role check into filter chain

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ dependencies {
     implementation 'no.fint:fint-event-model:3.0.2'
     implementation 'no.fintlabs:fint-core-infra-models:2.1.0-rc-5'
     implementation 'no.novari:kafka:6.0.0'
-    implementation 'no.fintlabs:fint-core-resource-server-security:2.1.2'
+    implementation 'no.novari:fint-core-principal:4.1.0'
     // Version 3 of metamodel supports v4 of information model
     implementation 'no.novari:fint-core-metamodel:3.0.0'
 

--- a/src/main/java/no/fintlabs/provider/ProviderController.kt
+++ b/src/main/java/no/fintlabs/provider/ProviderController.kt
@@ -51,32 +51,32 @@ class ProviderController(
         return ResponseEntity.ok("💗")
     }
 
-    @PostMapping("{domain}/{packageName}/{entity}")
+    @PostMapping("{domainName}/{packageName}/{entity}")
     suspend fun fullSync(
         @AuthenticationPrincipal corePrincipal: CorePrincipal,
         @RequestBody syncPage: FullSyncPage,
-        @PathVariable domain: String,
+        @PathVariable domainName: String,
         @PathVariable packageName: String,
         @PathVariable entity: String,
-    ): ResponseEntity<Void> = handleSync(corePrincipal, syncPage, domain, packageName, entity, HttpStatus.CREATED)
+    ): ResponseEntity<Void> = handleSync(corePrincipal, syncPage, domainName, packageName, entity, HttpStatus.CREATED)
 
-    @PatchMapping("{domain}/{packageName}/{entity}")
+    @PatchMapping("{domainName}/{packageName}/{entity}")
     suspend fun deltaSync(
         @AuthenticationPrincipal corePrincipal: CorePrincipal,
         @RequestBody syncPage: DeltaSyncPage,
-        @PathVariable domain: String,
+        @PathVariable domainName: String,
         @PathVariable packageName: String,
         @PathVariable entity: String,
-    ): ResponseEntity<Void> = handleSync(corePrincipal, syncPage, domain, packageName, entity, HttpStatus.CREATED)
+    ): ResponseEntity<Void> = handleSync(corePrincipal, syncPage, domainName, packageName, entity, HttpStatus.CREATED)
 
-    @DeleteMapping("{domain}/{packageName}/{entity}")
+    @DeleteMapping("{domainName}/{packageName}/{entity}")
     suspend fun deleteSync(
         @AuthenticationPrincipal corePrincipal: CorePrincipal,
         @RequestBody syncPage: DeleteSyncPage,
-        @PathVariable domain: String,
+        @PathVariable domainName: String,
         @PathVariable packageName: String,
         @PathVariable entity: String,
-    ): ResponseEntity<Void> = handleSync(corePrincipal, syncPage, domain, packageName, entity, HttpStatus.OK)
+    ): ResponseEntity<Void> = handleSync(corePrincipal, syncPage, domainName, packageName, entity, HttpStatus.OK)
 
     @PostMapping("register")
     fun register(
@@ -93,7 +93,7 @@ class ProviderController(
     private suspend fun handleSync(
         corePrincipal: CorePrincipal,
         syncPage: SyncPage,
-        domain: String,
+        domainName: String,
         packageName: String,
         entity: String,
         status: HttpStatus,
@@ -105,12 +105,12 @@ class ProviderController(
         // TODO: Disabled until contracts are in database
 //        requestValidator.validateAdapterCapabilityPermission(
 //            syncPage.metadata.adapterId,
-//            domain,
+//            domainName,
 //            packageName,
 //            entity,
 //        )
 
-        syncPageService.doSync(syncPage, domain, packageName, entity)
+        syncPageService.doSync(syncPage, domainName, packageName, entity)
         return ResponseEntity.status(status).build()
     }
 }

--- a/src/main/java/no/fintlabs/provider/ProviderController.kt
+++ b/src/main/java/no/fintlabs/provider/ProviderController.kt
@@ -7,7 +7,7 @@ import no.fintlabs.adapter.models.sync.DeleteSyncPage
 import no.fintlabs.adapter.models.sync.DeltaSyncPage
 import no.fintlabs.adapter.models.sync.FullSyncPage
 import no.fintlabs.adapter.models.sync.SyncPage
-import no.fintlabs.core.resource.server.security.authentication.CorePrincipal
+import no.novari.resource.server.authentication.CorePrincipal
 import no.fintlabs.provider.datasync.SyncPageService
 import no.fintlabs.provider.heartbeat.HeartbeatService
 import no.fintlabs.provider.register.RegistrationService
@@ -99,7 +99,6 @@ class ProviderController(
         status: HttpStatus,
     ): ResponseEntity<Void> {
         requestValidator.validateOrgId(corePrincipal, syncPage.metadata.orgId)
-        requestValidator.validateRole(corePrincipal, domain, packageName)
         // TODO: Enable validationg of AdapterId once we persist AdapterContracts
         //        requestValidator.validateAdapterId(corePrincipal, syncPage.getMetadata().getAdapterId());
 

--- a/src/main/java/no/fintlabs/provider/datasync/SyncPageService.kt
+++ b/src/main/java/no/fintlabs/provider/datasync/SyncPageService.kt
@@ -23,7 +23,7 @@ class SyncPageService(
 
     suspend fun <T : SyncPage> doSync(
         syncPage: T,
-        domain: String,
+        domainName: String,
         packageName: String,
         entity: String,
     ) = syncPage.logSync {
@@ -31,7 +31,7 @@ class SyncPageService(
             syncPage.resources.forEach { syncPageEntry -> syncPageEntry.resource = null }
         }
 
-        mutateMetadata(syncPage.metadata, domain, packageName, entity)
+        mutateMetadata(syncPage.metadata, domainName, packageName, entity)
         val syncType = syncPage.syncType.toString().lowercase()
         val eventName = "adapter-$syncType-sync"
         metaDataKafkaProducer.send(syncPage.metadata, eventName)
@@ -40,12 +40,12 @@ class SyncPageService(
 
     private fun mutateMetadata(
         syncPageMetadata: SyncPageMetadata,
-        domain: String,
+        domainName: String,
         packageName: String,
         resourceName: String,
     ) {
         syncPageMetadata.time = System.currentTimeMillis()
-        syncPageMetadata.uriRef = domain.lowercase() + '/' + packageName.lowercase() + '/' + resourceName.lowercase()
+        syncPageMetadata.uriRef = domainName.lowercase() + '/' + packageName.lowercase() + '/' + resourceName.lowercase()
     }
 
     private suspend fun sendEntities(page: SyncPage) = coroutineScope {

--- a/src/main/java/no/fintlabs/provider/event/EventController.java
+++ b/src/main/java/no/fintlabs/provider/event/EventController.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import no.fintlabs.adapter.models.event.RequestFintEvent;
 import no.fintlabs.adapter.models.event.ResponseFintEvent;
-import no.fintlabs.core.resource.server.security.authentication.CorePrincipal;
+import no.novari.resource.server.authentication.CorePrincipal;
 import no.fintlabs.provider.event.request.RequestEventService;
 import no.fintlabs.provider.event.response.ResponseEventService;
 import no.fintlabs.provider.exception.InvalidOrgIdException;

--- a/src/main/java/no/fintlabs/provider/event/response/ResponseEventService.java
+++ b/src/main/java/no/fintlabs/provider/event/response/ResponseEventService.java
@@ -5,7 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import no.fintlabs.adapter.models.event.RequestFintEvent;
 import no.fintlabs.adapter.models.event.ResponseFintEvent;
 import no.fintlabs.adapter.operation.OperationType;
-import no.fintlabs.core.resource.server.security.authentication.CorePrincipal;
+import no.novari.resource.server.authentication.CorePrincipal;
 import no.fintlabs.provider.datasync.EntityProducer;
 import no.fintlabs.provider.event.request.RequestEventService;
 import no.fintlabs.provider.exception.InvalidOrgIdException;

--- a/src/main/java/no/fintlabs/provider/exception/ExceptionController.java
+++ b/src/main/java/no/fintlabs/provider/exception/ExceptionController.java
@@ -42,12 +42,6 @@ public class ExceptionController {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
     }
 
-    @ExceptionHandler(MissingRoleException.class)
-    public ResponseEntity<String> handleMissingRoleException(Throwable e) {
-        providerErrorPublisher.publish(ProviderError.from(e));
-        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(e.getMessage());
-    }
-
     @ExceptionHandler(CapabilityNotSupportedException.class)
     public ResponseEntity<String> handleCapabilityNotSupportedException(Throwable e) {
         providerErrorPublisher.publish(ProviderError.from(e));

--- a/src/main/java/no/fintlabs/provider/exception/MissingRoleException.java
+++ b/src/main/java/no/fintlabs/provider/exception/MissingRoleException.java
@@ -1,7 +1,0 @@
-package no.fintlabs.provider.exception;
-
-public class MissingRoleException extends RuntimeException {
-    public MissingRoleException(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/no/fintlabs/provider/kafka/topic/TopicCleanupService.kt
+++ b/src/main/java/no/fintlabs/provider/kafka/topic/TopicCleanupService.kt
@@ -174,9 +174,9 @@ class TopicCleanupService(
      * never deleted by the cleanup pass, even when they match the `fint-core` filter.
      *
      * The set contains, for every `(component, orgId)` pair in `components.yaml`:
-     *  - the entity topic (`<orgId>.fint-core.entity.<domain>-<package>`)
-     *  - the request event topic (`<orgId>.fint-core.event.<domain>-<package>-request`)
-     *  - the response event topic (`<orgId>.fint-core.event.<domain>-<package>-response`)
+     *  - the entity topic (`<orgId>.fint-core.entity.<domainName>-<packageName>`)
+     *  - the request event topic (`<orgId>.fint-core.event.<domainName>-<packageName>-request`)
+     *  - the response event topic (`<orgId>.fint-core.event.<domainName>-<packageName>-response`)
      *  - the relation-update topic — only when the component has `relation-update: true`
      *
      * It also contains the eight global event topics under the application-default orgId:

--- a/src/main/java/no/fintlabs/provider/register/AdapterRegistrationTopicService.kt
+++ b/src/main/java/no/fintlabs/provider/register/AdapterRegistrationTopicService.kt
@@ -22,7 +22,7 @@ class AdapterRegistrationTopicService(
     private val ensuredTopics = ConcurrentHashMap.newKeySet<String>()
 
     /**
-     * Ensures a Kafka entity topic exists for each unique component (domain-package combination)
+     * Ensures a Kafka entity topic exists for each unique component (domainName-packageName combination)
      * in the adapter contract. Topics are created per org, and if a topic has already been
      * ensured for a given org and component in this runtime, it is skipped.
      *

--- a/src/main/java/no/fintlabs/provider/security/AdapterRequestValidator.java
+++ b/src/main/java/no/fintlabs/provider/security/AdapterRequestValidator.java
@@ -3,7 +3,7 @@ package no.fintlabs.provider.security;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import no.fintlabs.core.resource.server.security.authentication.CorePrincipal;
+import no.novari.resource.server.authentication.CorePrincipal;
 import no.fintlabs.provider.exception.*;
 import org.springframework.stereotype.Component;
 
@@ -28,24 +28,17 @@ public class AdapterRequestValidator {
     }
 
     public void validateOrgId(CorePrincipal corePrincipal, String requestedOrgId) {
-        if (corePrincipal.doesNotContainAsset(requestedOrgId.replace("-", ".").replace("_", "."))) {
+        String normalized = requestedOrgId.replace("-", ".").replace("_", ".");
+        if (!corePrincipal.getAssets().contains(normalized)) {
             log.warn("Validation failed: JWT for user '{}' does not have access to organization '{}'. Available assets: {}", corePrincipal.getUsername(), requestedOrgId, corePrincipal.getAssets());
             throw new InvalidOrgId("Adapter assets does not contain the organization for the request");
         }
     }
 
     public void validateUsername(CorePrincipal corePrincipal, String contractUsername) {
-        if (corePrincipal.doesNotHaveMatchingUsername(contractUsername)) {
+        if (!corePrincipal.getUsername().equals(contractUsername)) {
             log.warn("Validation failed: Username mismatch. JWT's username '{}' does not match contract username '{}'.", corePrincipal.getUsername(), contractUsername);
             throw new InvalidUsername("Adapter username does not match contract username");
-        }
-    }
-
-    public void validateRole(CorePrincipal corePrincipal, String domain, String packageName) {
-        String role = String.format("FINT_Adapter_%s_%s", domain.toLowerCase(), packageName.toLowerCase());
-        if (corePrincipal.doesNotHaveRole(role)) {
-            log.warn("Validation failed: Principal '{}' is missing required role '{}'. Current roles: {}", corePrincipal.getUsername(), role, corePrincipal.getRoles());
-            throw new MissingRoleException("Adapter does not have the correct role to perform this action");
         }
     }
 }

--- a/src/main/java/no/fintlabs/provider/security/SecurityConfiguration.kt
+++ b/src/main/java/no/fintlabs/provider/security/SecurityConfiguration.kt
@@ -54,16 +54,15 @@ class SecurityConfiguration {
         context: AuthorizationContext,
     ): Mono<AuthorizationDecision> =
         authentication
-            .map { auth ->
-                val domainName = context.variables["domainName"] as? String
-                val packageName = context.variables["packageName"] as? String
-                AuthorizationDecision(
-                    auth.isFintAdapter() &&
-                            domainName != null && packageName != null &&
-                            (auth as CorePrincipal).hasComponent(domainName, packageName)
-                )
-            }
+            .map { AuthorizationDecision(it.canAccessComponent(context)) }
             .defaultIfEmpty(AuthorizationDecision(false))
+
+    private fun Authentication.canAccessComponent(context: AuthorizationContext): Boolean {
+        if (this !is CorePrincipal || !isFintAdapter()) return false
+        val domainName = context.variables["domainName"] as? String ?: return false
+        val packageName = context.variables["packageName"] as? String ?: return false
+        return hasComponent(domainName, packageName)
+    }
 
     private fun Authentication.isFintAdapter(): Boolean =
         isAuthenticated && this is CorePrincipal && type == FintType.ADAPTER && FintScope.FINT_ADAPTER in scopes

--- a/src/main/java/no/fintlabs/provider/security/SecurityConfiguration.kt
+++ b/src/main/java/no/fintlabs/provider/security/SecurityConfiguration.kt
@@ -1,0 +1,84 @@
+package no.fintlabs.provider.security
+
+import no.novari.resource.server.authentication.CorePrincipal
+import no.novari.resource.server.converter.CorePrincipalConverter
+import no.novari.resource.server.enums.FintScope
+import no.novari.resource.server.enums.FintType
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpMethod
+import org.springframework.security.authorization.AuthorizationDecision
+import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity
+import org.springframework.security.config.web.server.ServerHttpSecurity
+import org.springframework.security.core.Authentication
+import org.springframework.security.oauth2.server.resource.authentication.ReactiveJwtAuthenticationConverterAdapter
+import org.springframework.security.web.server.SecurityWebFilterChain
+import org.springframework.security.web.server.authorization.AuthorizationContext
+import reactor.core.publisher.Mono
+
+@Configuration
+@EnableWebFluxSecurity
+class SecurityConfiguration {
+
+    @Bean
+    fun securityWebFilterChain(http: ServerHttpSecurity): SecurityWebFilterChain =
+        http
+            .csrf { it.disable() }
+            .authorizeExchange { exchange ->
+                exchange
+                    .pathMatchers(*OPEN_PATHS).permitAll()
+                    .pathMatchers(HttpMethod.POST, SYNC_PATH).access(::requireAdapterWithComponent)
+                    .pathMatchers(HttpMethod.PATCH, SYNC_PATH).access(::requireAdapterWithComponent)
+                    .pathMatchers(HttpMethod.DELETE, SYNC_PATH).access(::requireAdapterWithComponent)
+                    .anyExchange().access(::requireAdapter)
+            }
+            .oauth2ResourceServer { oauth2 ->
+                oauth2.jwt { jwt ->
+                    jwt.jwtAuthenticationConverter(
+                        ReactiveJwtAuthenticationConverterAdapter(CorePrincipalConverter())
+                    )
+                }
+            }
+            .build()
+
+    private fun requireAdapter(
+        authentication: Mono<Authentication>,
+        @Suppress("UNUSED_PARAMETER") context: AuthorizationContext,
+    ): Mono<AuthorizationDecision> =
+        authentication
+            .map { AuthorizationDecision(it.isFintAdapter()) }
+            .defaultIfEmpty(AuthorizationDecision(false))
+
+    private fun requireAdapterWithComponent(
+        authentication: Mono<Authentication>,
+        context: AuthorizationContext,
+    ): Mono<AuthorizationDecision> =
+        authentication
+            .map { auth ->
+                val domain = context.variables["domain"] as? String
+                val pkg = context.variables["packageName"] as? String
+                AuthorizationDecision(
+                    auth.isFintAdapter() &&
+                        domain != null && pkg != null &&
+                        (auth as CorePrincipal).hasComponent(domain, pkg)
+                )
+            }
+            .defaultIfEmpty(AuthorizationDecision(false))
+
+    private fun Authentication.isFintAdapter(): Boolean =
+        isAuthenticated &&
+            this is CorePrincipal &&
+            type == FintType.ADAPTER &&
+            FintScope.FINT_ADAPTER in scopes
+
+    companion object {
+        private const val SYNC_PATH = "/{domain}/{packageName}/{entity}"
+        private val OPEN_PATHS = arrayOf(
+            "/api-docs/**",
+            "/swagger/**",
+            "/actuator/health",
+            "/ready",
+            "/offset",
+        )
+    }
+}

--- a/src/main/java/no/fintlabs/provider/security/SecurityConfiguration.kt
+++ b/src/main/java/no/fintlabs/provider/security/SecurityConfiguration.kt
@@ -56,11 +56,11 @@ class SecurityConfiguration {
         authentication
             .map { auth ->
                 val domainName = context.variables["domainName"] as? String
-                val pkg = context.variables["packageName"] as? String
+                val packageName = context.variables["packageName"] as? String
                 AuthorizationDecision(
                     auth.isFintAdapter() &&
-                            domainName != null && pkg != null &&
-                            (auth as CorePrincipal).hasComponent(domainName, pkg)
+                            domainName != null && packageName != null &&
+                            (auth as CorePrincipal).hasComponent(domainName, packageName)
                 )
             }
             .defaultIfEmpty(AuthorizationDecision(false))

--- a/src/main/java/no/fintlabs/provider/security/SecurityConfiguration.kt
+++ b/src/main/java/no/fintlabs/provider/security/SecurityConfiguration.kt
@@ -43,7 +43,7 @@ class SecurityConfiguration {
 
     private fun requireAdapter(
         authentication: Mono<Authentication>,
-        @Suppress("UNUSED_PARAMETER") context: AuthorizationContext,
+        context: AuthorizationContext,
     ): Mono<AuthorizationDecision> =
         authentication
             .map { AuthorizationDecision(it.isFintAdapter()) }
@@ -55,24 +55,21 @@ class SecurityConfiguration {
     ): Mono<AuthorizationDecision> =
         authentication
             .map { auth ->
-                val domain = context.variables["domain"] as? String
+                val domainName = context.variables["domainName"] as? String
                 val pkg = context.variables["packageName"] as? String
                 AuthorizationDecision(
                     auth.isFintAdapter() &&
-                        domain != null && pkg != null &&
-                        (auth as CorePrincipal).hasComponent(domain, pkg)
+                            domainName != null && pkg != null &&
+                            (auth as CorePrincipal).hasComponent(domainName, pkg)
                 )
             }
             .defaultIfEmpty(AuthorizationDecision(false))
 
     private fun Authentication.isFintAdapter(): Boolean =
-        isAuthenticated &&
-            this is CorePrincipal &&
-            type == FintType.ADAPTER &&
-            FintScope.FINT_ADAPTER in scopes
+        isAuthenticated && this is CorePrincipal && type == FintType.ADAPTER && FintScope.FINT_ADAPTER in scopes
 
     companion object {
-        private const val SYNC_PATH = "/{domain}/{packageName}/{entity}"
+        private const val SYNC_PATH = "/{domainName}/{packageName}/{entity}"
         private val OPEN_PATHS = arrayOf(
             "/api-docs/**",
             "/swagger/**",

--- a/src/main/java/no/fintlabs/provider/security/resource/ComponentResourceRegistry.kt
+++ b/src/main/java/no/fintlabs/provider/security/resource/ComponentResourceRegistry.kt
@@ -12,8 +12,8 @@ class ComponentResourceRegistry(
     private val resourceIdentifiers: Set<String> = createResourceIdentifiers(metamodelService)
 
     /**
-     * Checks if a resource defined by the given combination of domain, package, and resource name exists.
-     * * @param domainName The domain component.
+     * Checks if a resource defined by the given combination of domainName, packageName, and resourceName exists.
+     * @param domainName The domain component.
      * @param packageName The package component.
      * @param resourceName The resource name component.
      * @return true if the combined resource identifier exists in the registry, false otherwise.

--- a/src/test/java/no/fintlabs/provider/ProviderControllerIntegrationTest.kt
+++ b/src/test/java/no/fintlabs/provider/ProviderControllerIntegrationTest.kt
@@ -8,7 +8,7 @@ import no.fintlabs.adapter.models.sync.DeltaSyncPage
 import no.fintlabs.adapter.models.sync.FullSyncPage
 import no.fintlabs.adapter.models.sync.SyncPageEntry
 import no.fintlabs.adapter.models.sync.SyncPageMetadata
-import no.fintlabs.core.resource.server.security.authentication.CorePrincipal
+import no.novari.resource.server.authentication.CorePrincipal
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test

--- a/src/test/java/no/fintlabs/provider/ProviderControllerIntegrationTest.kt
+++ b/src/test/java/no/fintlabs/provider/ProviderControllerIntegrationTest.kt
@@ -158,34 +158,6 @@ class ProviderControllerIntegrationTest {
     }
 
     @Test
-    fun `Should reject sync request if JWT lacks the required role`() {
-        val invalidJwt = Jwt.withTokenValue("mock-token")
-            .header("alg", "none")
-            .claim("cn", username)
-            .claim("fintAssetIDs", orgId)
-            .claim("scope", listOf("fint-adapter"))
-            .claim("Roles", listOf("FINT_Adapter_wrong_role"))
-            .build()
-
-        val invalidPrincipal = CorePrincipal(invalidJwt, listOf(SimpleGrantedAuthority("ROLE_ADAPTER")))
-
-        val syncPage = FullSyncPage().apply {
-            this.metadata = SyncPageMetadata().apply {
-                this.orgId = this@ProviderControllerIntegrationTest.orgId
-                this.adapterId = this@ProviderControllerIntegrationTest.adapterId
-            }
-        }
-
-        client.mutateWith(mockAuthentication(invalidPrincipal))
-            .post()
-            .uri("/$domainName/$packageName/$resourceName")
-            .contentType(MediaType.APPLICATION_JSON)
-            .bodyValue(syncPage)
-            .exchange()
-            .expectStatus().isForbidden
-    }
-
-    @Test
     fun `Should successfully perform deltaSync`() {
         registerAdapter()
 

--- a/src/test/java/no/fintlabs/provider/event/request/RequestEventServiceTest.kt
+++ b/src/test/java/no/fintlabs/provider/event/request/RequestEventServiceTest.kt
@@ -221,14 +221,14 @@ class RequestEventServiceTest {
     private fun createEvent(
         id: String?,
         org: String?,
-        domain: String?,
+        domainName: String?,
         pkg: String?,
         res: String?
     ): RequestFintEvent {
         return RequestFintEvent().apply {
             corrId = id
             orgId = org
-            domainName = domain
+            this.domainName = domainName
             packageName = pkg
             resourceName = res
         }

--- a/src/test/java/no/fintlabs/provider/security/AdapterRequestValidatorTest.java
+++ b/src/test/java/no/fintlabs/provider/security/AdapterRequestValidatorTest.java
@@ -1,61 +1,51 @@
 package no.fintlabs.provider.security;
 
-import no.fintlabs.core.resource.server.security.authentication.CorePrincipal;
-import no.fintlabs.provider.exception.MissingRoleException;
-import no.fintlabs.provider.security.AdapterRequestValidator;
+import no.novari.resource.server.authentication.CorePrincipal;
+import no.fintlabs.provider.exception.InvalidOrgId;
 import no.fintlabs.provider.exception.InvalidUsername;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-import org.springframework.web.server.ResponseStatusException;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.when;
 
 public class AdapterRequestValidatorTest {
 
-    @Mock
-    private CorePrincipal corePrincipal;
+    private final AdapterRequestValidator validator = new AdapterRequestValidator(new AdapterContractContext());
 
-    @InjectMocks
-    private AdapterRequestValidator adapterRequestValidator;
-
-    @BeforeEach
-    public void setup() {
-        MockitoAnnotations.openMocks(this);
+    private CorePrincipal principal(String username, String assetIds) {
+        Jwt jwt = Jwt.withTokenValue("token")
+                .header("alg", "none")
+                .claim("cn", username)
+                .claim("fintAssetIDs", assetIds)
+                .claim("scope", List.of("fint-adapter"))
+                .build();
+        return new CorePrincipal(jwt, List.of());
     }
 
     @Test
-    public void shouldThrowExceptionWhenRoleMismatch() {
-        when(corePrincipal.doesNotHaveRole(anyString())).thenReturn(true);
-        assertThrows(MissingRoleException.class, () -> adapterRequestValidator.validateRole(corePrincipal, "domain", "package"));
+    public void shouldNotThrowWhenOrgIdInAssets() {
+        CorePrincipal p = principal("test@adapter.test.org.no", "test.org.no");
+        assertDoesNotThrow(() -> validator.validateOrgId(p, "test-org-no"));
     }
 
     @Test
-    public void shouldNotThrowExceptionWhenRoleMatch() {
-        when(corePrincipal.doesNotHaveRole(anyString())).thenReturn(false);
-        assertDoesNotThrow(() -> adapterRequestValidator.validateRole(corePrincipal, "domain", "package"));
+    public void shouldThrowWhenOrgIdNotInAssets() {
+        CorePrincipal p = principal("test@adapter.test.org.no", "test.org.no");
+        assertThrows(InvalidOrgId.class, () -> validator.validateOrgId(p, "other-org-no"));
     }
 
     @Test
-    public void shouldNotThrowExceptionWhenOrgIdMatch() {
-        when(corePrincipal.doesNotHaveMatchingOrgId(anyString())).thenReturn(false);
-        assertDoesNotThrow(() -> adapterRequestValidator.validateOrgId(corePrincipal, "orgId"));
+    public void shouldThrowWhenUsernameMismatch() {
+        CorePrincipal p = principal("test@adapter.test.org.no", "test.org.no");
+        assertThrows(InvalidUsername.class, () -> validator.validateUsername(p, "someone_else"));
     }
 
     @Test
-    public void shouldThrowExceptionWhenUsernameMismatch() {
-        when(corePrincipal.doesNotHaveMatchingUsername(anyString())).thenReturn(true);
-        assertThrows(InvalidUsername.class, () -> adapterRequestValidator.validateUsername(corePrincipal, "username"));
-    }
-
-    @Test
-    public void shouldNotThrowExceptionWhenUsernameMatch() {
-        when(corePrincipal.doesNotHaveMatchingUsername(anyString())).thenReturn(false);
-        assertDoesNotThrow(() -> adapterRequestValidator.validateUsername(corePrincipal, "username"));
+    public void shouldNotThrowWhenUsernameMatches() {
+        CorePrincipal p = principal("test@adapter.test.org.no", "test.org.no");
+        assertDoesNotThrow(() -> validator.validateUsername(p, "test@adapter.test.org.no"));
     }
 }

--- a/src/test/kotlin/no/fintlabs/provider/security/SecurityConfigurationTest.kt
+++ b/src/test/kotlin/no/fintlabs/provider/security/SecurityConfigurationTest.kt
@@ -1,0 +1,155 @@
+package no.fintlabs.provider.security
+
+import no.novari.kafka.KafkaConfiguration
+import no.novari.resource.server.authentication.CorePrincipal
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration
+import org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.ApplicationContext
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Import
+import org.springframework.context.annotation.Profile
+import org.springframework.http.MediaType
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.jwt.ReactiveJwtDecoder
+import org.springframework.security.test.web.reactive.server.SecurityMockServerConfigurers.mockAuthentication
+import org.springframework.security.test.web.reactive.server.SecurityMockServerConfigurers.springSecurity
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.reactive.server.WebTestClient
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RestController
+
+@SpringBootTest(
+    classes = [SecurityConfigurationTest.TestApp::class],
+    webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+)
+@ActiveProfiles(SecurityConfigurationTest.PROFILE)
+class SecurityConfigurationTest {
+
+    @Autowired
+    private lateinit var context: ApplicationContext
+
+    @MockitoBean
+    private lateinit var jwtDecoder: ReactiveJwtDecoder
+
+    private lateinit var client: WebTestClient
+
+    @BeforeEach
+    fun setup() {
+        client = WebTestClient
+            .bindToApplicationContext(context)
+            .apply(springSecurity())
+            .configureClient()
+            .build()
+    }
+
+    @Test
+    fun `open path is reachable without authentication`() {
+        client.get().uri("/ready").exchange()
+            .expectStatus().isOk
+    }
+
+    @Test
+    fun `unauthenticated request to protected path returns 401`() {
+        client.get().uri("/status").exchange()
+            .expectStatus().isUnauthorized
+    }
+
+    @Test
+    fun `client principal is denied on protected path`() {
+        client.mutateWith(mockAuthentication(principal(cn = "client@client.fintlabs.no", scope = "fint-client")))
+            .get().uri("/status").exchange()
+            .expectStatus().isForbidden
+    }
+
+    @Test
+    fun `adapter without fint-adapter scope is denied`() {
+        client.mutateWith(mockAuthentication(adapter(scope = "fint-client")))
+            .get().uri("/status").exchange()
+            .expectStatus().isForbidden
+    }
+
+    @Test
+    fun `adapter with fint-adapter scope passes baseline check`() {
+        client.mutateWith(mockAuthentication(adapter()))
+            .get().uri("/status").exchange()
+            .expectStatus().isOk
+    }
+
+    @Test
+    fun `sync endpoint denies adapter without matching component`() {
+        client.mutateWith(mockAuthentication(adapter(roles = listOf("FINT_Adapter_utdanning_elev"))))
+            .post().uri("/utdanning/vurdering/elev")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue("{}")
+            .exchange()
+            .expectStatus().isForbidden
+    }
+
+    @Test
+    fun `sync endpoint allows adapter with matching component`() {
+        client.mutateWith(mockAuthentication(adapter(roles = listOf("FINT_Adapter_utdanning_elev"))))
+            .post().uri("/utdanning/elev/elev")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue("{}")
+            .exchange()
+            .expectStatus().isOk
+    }
+
+    private fun adapter(
+        scope: String = "fint-adapter",
+        roles: List<String> = emptyList(),
+    ): CorePrincipal = principal(
+        cn = "test@adapter.fintlabs.no",
+        scope = scope,
+        roles = roles,
+    )
+
+    private fun principal(
+        cn: String,
+        scope: String,
+        roles: List<String> = emptyList(),
+    ): CorePrincipal {
+        val jwt = Jwt.withTokenValue("token")
+            .header("alg", "none")
+            .claim("cn", cn)
+            .claim("fintAssetIDs", "fintlabs.no")
+            .claim("scope", listOf(scope))
+            .claim("Roles", roles)
+            .build()
+        return CorePrincipal(jwt, emptyList())
+    }
+
+    @Configuration
+    @Profile(PROFILE)
+    @EnableAutoConfiguration(exclude = [KafkaAutoConfiguration::class, KafkaConfiguration::class])
+    @Import(SecurityConfiguration::class, Endpoints::class)
+    class TestApp
+
+    @RestController
+    @Profile(PROFILE)
+    class Endpoints {
+        @GetMapping("/ready")
+        fun ready(): String = "ok"
+
+        @GetMapping("/status")
+        fun status(): String = "ok"
+
+        @PostMapping("/{domain}/{packageName}/{entity}")
+        fun sync(
+            @PathVariable domain: String,
+            @PathVariable packageName: String,
+            @PathVariable entity: String,
+        ): String = "$domain/$packageName/$entity"
+    }
+
+    companion object {
+        const val PROFILE = "security-config-test"
+    }
+}

--- a/src/test/kotlin/no/fintlabs/provider/security/SecurityConfigurationTest.kt
+++ b/src/test/kotlin/no/fintlabs/provider/security/SecurityConfigurationTest.kt
@@ -35,9 +35,6 @@ class SecurityConfigurationTest {
     @Autowired
     private lateinit var context: ApplicationContext
 
-    @MockitoBean
-    private lateinit var jwtDecoder: ReactiveJwtDecoder
-
     private lateinit var client: WebTestClient
 
     @BeforeEach
@@ -102,6 +99,67 @@ class SecurityConfigurationTest {
             .expectStatus().isOk
     }
 
+    @Test
+    fun `event POST is unauthenticated rejected`() {
+        client.post().uri("/event")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue("{}")
+            .exchange()
+            .expectStatus().isUnauthorized
+    }
+
+    @Test
+    fun `event POST denies client scope`() {
+        client.mutateWith(mockAuthentication(principal(cn = "client@client.fintlabs.no", scope = "fint-client")))
+            .post().uri("/event")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue("{}")
+            .exchange()
+            .expectStatus().isForbidden
+    }
+
+    @Test
+    fun `event POST passes filter chain for any fint-adapter regardless of roles`() {
+        client.mutateWith(mockAuthentication(adapter()))
+            .post().uri("/event")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue("{}")
+            .exchange()
+            .expectStatus().isOk
+    }
+
+    @Test
+    fun `event GET domain passes filter chain for any fint-adapter regardless of roles`() {
+        client.mutateWith(mockAuthentication(adapter()))
+            .get().uri("/event/utdanning")
+            .exchange()
+            .expectStatus().isOk
+    }
+
+    @Test
+    fun `event GET domain-package passes filter chain even when component does not match roles`() {
+        client.mutateWith(mockAuthentication(adapter(roles = listOf("FINT_Adapter_utdanning_elev"))))
+            .get().uri("/event/utdanning/vurdering")
+            .exchange()
+            .expectStatus().isOk
+    }
+
+    @Test
+    fun `event GET domain-package-resource passes filter chain for any fint-adapter`() {
+        client.mutateWith(mockAuthentication(adapter()))
+            .get().uri("/event/utdanning/elev/elev")
+            .exchange()
+            .expectStatus().isOk
+    }
+
+    @Test
+    fun `event GET denies client scope`() {
+        client.mutateWith(mockAuthentication(principal(cn = "client@client.fintlabs.no", scope = "fint-client")))
+            .get().uri("/event/utdanning")
+            .exchange()
+            .expectStatus().isForbidden
+    }
+
     private fun adapter(
         scope: String = "fint-adapter",
         roles: List<String> = emptyList(),
@@ -147,6 +205,25 @@ class SecurityConfigurationTest {
             @PathVariable packageName: String,
             @PathVariable entity: String,
         ): String = "$domainName/$packageName/$entity"
+
+        @PostMapping("/event")
+        fun postEvent(): String = "ok"
+
+        @GetMapping("/event/{domainName}")
+        fun getEventsDomain(@PathVariable domainName: String): String = domainName
+
+        @GetMapping("/event/{domainName}/{packageName}")
+        fun getEventsPackage(
+            @PathVariable domainName: String,
+            @PathVariable packageName: String,
+        ): String = "$domainName/$packageName"
+
+        @GetMapping("/event/{domainName}/{packageName}/{resourceName}")
+        fun getEventsResource(
+            @PathVariable domainName: String,
+            @PathVariable packageName: String,
+            @PathVariable resourceName: String,
+        ): String = "$domainName/$packageName/$resourceName"
     }
 
     companion object {

--- a/src/test/kotlin/no/fintlabs/provider/security/SecurityConfigurationTest.kt
+++ b/src/test/kotlin/no/fintlabs/provider/security/SecurityConfigurationTest.kt
@@ -141,12 +141,12 @@ class SecurityConfigurationTest {
         @GetMapping("/status")
         fun status(): String = "ok"
 
-        @PostMapping("/{domain}/{packageName}/{entity}")
+        @PostMapping("/{domainName}/{packageName}/{entity}")
         fun sync(
-            @PathVariable domain: String,
+            @PathVariable domainName: String,
             @PathVariable packageName: String,
             @PathVariable entity: String,
-        ): String = "$domain/$packageName/$entity"
+        ): String = "$domainName/$packageName/$entity"
     }
 
     companion object {


### PR DESCRIPTION
## Summary

Migrates security to `no.novari:fint-core-principal` 4.1 and moves adapter/component authorization from a scattered `AdapterRequestValidator` role check into the Spring Security filter chain. Role violations now produce `401/403` at the filter chain instead of reaching controllers and throwing `MissingRoleException`.

## Security model

All requests go through a WebFlux resource server with JWT (`CorePrincipalConverter` from fint-core-principal 4.1).

**Filter chain** (`SecurityConfiguration.kt`):
- **Open paths** (permitAll): `/api-docs/**`, `/swagger/**`, `/actuator/health`, `/ready`, `/offset`.
- **`POST|PATCH|DELETE /{domainName}/{packageName}/{entity}`** (sync endpoints) → `requireAdapterWithComponent`: caller must be authenticated, be a `CorePrincipal` of type `ADAPTER`, carry the `fint-adapter` scope, **and** have `hasComponent(domainName, packageName)` according to the JWT's roles. Unmatched component → 403.
- **Any other exchange** (incl. `/event/**`) → `requireAdapter`: authenticated `fint-adapter` `CorePrincipal` only; component/role is not asserted at the filter chain (GETs on `/event/**` intentionally don't gate on role so adapters can poll without role-per-path setup).
- Unauthenticated → 401. `fint-client` scope → 403 on everything guarded.

**Controller-layer checks** (`AdapterRequestValidator`) remain for the sync path and assert identity/contract properties the filter can't see:
- `validateAdapterId` — adapter is registered in a contract (`adapterContractContext`).
- `validateUsername` — JWT username matches the contract username.
- `validateOrgId` — requested orgId is in the principal's assets.
- `validateAdapterCapabilityPermission` — the adapter's contract actually grants the `(domain, package, entity)` capability.

So authorization is layered: **filter chain** enforces coarse role/component from the JWT; **controller validators** enforce fine-grained contract/identity/capability from application state.

## Notable changes

- Drops `MissingRoleException` — the role rejection path is now the filter chain's 403.
- Renames `domain` → `domainName` across controller paths and validator signatures for consistency with `packageName`.
- Adds `SecurityConfigurationTest` slice test that boots only the filter chain with a mocked `ReactiveJwtDecoder` and covers: open paths, sync path role gating, `/event` POST/GET authz, `fint-client` scope rejection, unauthenticated rejection.
- Removes the integration test that duplicated the role-rejection scenario now covered by the slice test.